### PR TITLE
Added C++ FLAT

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Thank you for submitting a PR!
+
+If your PR includes C++ code, please adhere to the Google C++ Style Guide.
+
+For any C++ changes, please make sure to run `cd flat && sh format-files.sh`
+
+Include other details as appropriate.
+
+&& 
+
+If your pr includes Swift or ObjC, please adhere to the Apple Style Guide.
+
+Thanks!

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 **/xcuserdata/
 **/xcshareddata/
+**/CMakeCache.txt
+**/CMakeFiles
+**/CMakeScripts
+flat/**/*.xcodeproj
+flat/flatbuffers/
+flat/flatbuffers-build
+**/cmake_install.cmake
+**/FLAT.build
+**/Debug
+**/CPackConfig.cmake
+**/CPackSourceConfig.cmake
+**/CTestTestfile.cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+env:
+  global:
+    # Set at the root level as this is ignored when set under matrix.env.
+    - GCC_VERSION="4.9"
+    # Fail on first error if UBSAN or ASAN enabled for a target
+    - UBSAN_OPTIONS=halt_on_error=1
+    - ASAN_OPTIONS=halt_on_error=1
+    # Travis machines have 2 cores
+    - JOBS=2
+    - MAKEFLAGS="-j 2"
+
+matrix:
+  include:
+    - language: cpp
+      os: osx
+      osx_image: xcode11.2
+      env:
+        matrix:
+          - BUILD_TYPE=Debug
+          - BUILD_TYPE=Release
+
+      script:
+      - cd flat
+      - bash build.sh

--- a/flat/.clang-format
+++ b/flat/.clang-format
@@ -1,0 +1,11 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Right
+IndentPPDirectives: AfterHash
+Cpp11BracedListStyle: false
+AlwaysBreakTemplateDeclarations: false
+AllowShortCaseLabelsOnASingleLine: true
+SpaceAfterTemplateKeyword: false
+AllowShortBlocksOnASingleLine: true

--- a/flat/CMakeLists.txt
+++ b/flat/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 2.8.12)
+# generate compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+include(CheckCXXSymbolExists)
+
+project(FLAT)
+option(FLAT_CODE_COVERAGE "Enable the code coverage build option." ON)
+option(FLAT_BUILD_FLATLIB "Enable the build of the flatbuffers library"
+       ON)
+option(FLAT_BUILD_TESTS "Enable the build of tests and samples." ON)
+
+set(FLATBUFFERS_SRC_DIR flatbuffers)
+set(FLAT_Library_SRCS
+  src/flat/flat.hpp
+  src/flat/flat.cpp
+)
+
+set(Flat_Tests_SRCS
+  tests/testflat.cpp
+)
+
+if(APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
+  set(FLAT_PRIVATE_CXX_FLAGS "-Wold-style-cast")
+endif()
+
+if(FLAT_CODE_COVERAGE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
+endif()
+
+if(FLAT_BUILD_FLATLIB)
+    add_library(flat STATIC ${FLAT_Library_SRCS})
+    target_include_directories(flat INTERFACE 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+    target_compile_options(flat PRIVATE "${FLAT_PRIVATE_CXX_FLAGS}")
+endif()
+
+# Add FlatBuffers directly to our build. This defines the `flatbuffers` target.
+add_subdirectory(${FLATBUFFERS_SRC_DIR}
+                 ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers-build
+                 EXCLUDE_FROM_ALL)
+# Now simply link against flatbuffers as needed to your already declared target.
+# The flatbuffers target carry header search path automatically if CMake > 2.8.11.
+target_link_libraries(flat PRIVATE flatbuffers)
+
+
+if(FLAT_BUILD_TESTS)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/tests)
+  add_executable(tests ${Flat_Tests_SRCS})
+  target_link_libraries(tests PRIVATE flat)
+  target_link_libraries(tests PRIVATE flatbuffers)
+endif()

--- a/flat/README.md
+++ b/flat/README.md
@@ -1,0 +1,12 @@
+# FLAT
+
+ Flat is an open source project that allows you to pretty print Flatbuffers objects.
+
+# Install
+
+ The following library is dependent on the flatbuffers project
+ - Simply run `build.sh` to clone the flatbuffers repository & build the xcode project `cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release`
+
+# Contribution
+- We use clang-format `format-files.sh` that uses the google cpp style so if you are contributing please do format the files before PR's
+- The following project is an open source project.

--- a/flat/build.sh
+++ b/flat/build.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/google/flatbuffers.git
+cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release 

--- a/flat/format-files.sh
+++ b/flat/format-files.sh
@@ -1,0 +1,2 @@
+clang-format -i -style=file src/flat/* tests/*.cpp
+

--- a/flat/remove.sh
+++ b/flat/remove.sh
@@ -1,0 +1,10 @@
+rm -rf CMakeCache.txt
+rm -rf cmake_install.cmake
+rm -rf FLAT.xcodeproj
+rm -rf flatbuffers
+rm -rf flatbuffers-build
+rm -rf Debug
+rm -rf CMake
+rm -rf CMakeFiles
+rm -rf CMakeScripts
+rm -rf FLAT.build

--- a/flat/src/flat/flat.cpp
+++ b/flat/src/flat/flat.cpp
@@ -1,0 +1,10 @@
+#include "flat.hpp"
+
+#include <string>
+
+#include "flatbuffers/idl.h"
+
+namespace flat {
+
+std::string printer() { return "Hello Flat!"; };
+}

--- a/flat/src/flat/flat.hpp
+++ b/flat/src/flat/flat.hpp
@@ -1,0 +1,7 @@
+#include <string>
+
+#include "flatbuffers/idl.h"
+
+namespace flat {
+std::string printer();
+}

--- a/flat/tests/testflat.cpp
+++ b/flat/tests/testflat.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+#include "flat/flat.hpp"
+int main(int /*argc*/, const char * /*argv*/[]) {
+  std::cout << flat::printer() << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This PR adds the basic namespace for FLAT however I don't really like how I set it up with just a normal Xcode project. I would really love to create it so that anyone can actually contribute without the need to have Xcode. there is a way to generate an Xcode project from a cmake.
plus we would follow the google cpp style guide, which we can simply add a `.clang-format` for it. 
@adilanchian would love to have your input